### PR TITLE
Fix build error in powershell script

### DIFF
--- a/FFUDevelopment/BuildFFUVM.ps1
+++ b/FFUDevelopment/BuildFFUVM.ps1
@@ -2991,7 +2991,7 @@ function Get-ShortenedWindowsSKU {
         'ServerDatacenter' { 'Srv_Dtc' }
         'Datacenter' { 'Srv_Dtc' }
         'Standard (Desktop Experience)' { 'Srv_Std_DE' }
-        'Datacenter (Desktop Experience)' { 'Srv_Dtc_DE'  
+        'Datacenter (Desktop Experience)' { 'Srv_Dtc_DE' }
     }
     return $shortenedWindowsSKU
 


### PR DESCRIPTION
Add missing closing brace to a switch statement clause in `Get-ShortenedWindowsSKU` to fix PowerShell build errors.

---
<a href="https://cursor.com/background-agent?bcId=bc-7afb621c-98f3-440b-8456-85dc7a926e7f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-7afb621c-98f3-440b-8456-85dc7a926e7f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

