### PR TITLE
Fix build error unrecognized drive cmdlet

### DIFF
--- a/FFUDevelopment/BuildFFUVM.ps1
+++ b/FFUDevelopment/BuildFFUVM.ps1
@@ -631,6 +631,62 @@ if ($WindowsSKU -like "*LTS*") {
 # Set the log path for the common logger
 Set-CommonCoreLogPath -Path $LogFile
 
+function Get-DriveLetterAssignments {
+    <#
+    .SYNOPSIS
+    Gets drive letter assignments for all the partitions needed by the FFU creation process.
+    
+    .DESCRIPTION
+    This function assigns available drive letters for:
+    - System partition (prefers 'S')
+    - OS partition (prefers 'W') 
+    - Recovery partition (prefers 'R')
+    - Network share mapping (prefers 'X', 'Y', 'Z' to avoid conflicts)
+    
+    .OUTPUTS
+    Returns a hashtable with the assigned drive letters
+    #>
+    
+    WriteLog "Assigning available drive letters for FFU creation process..."
+    
+    $assignments = @{}
+    $usedLetters = @()
+    
+    try {
+        # Get system partition drive letter (prefer S)
+        $systemLetter = Get-AvailableDriveLetter -PreferredLetters @('S') -ExcludeLetters $usedLetters
+        $assignments.System = $systemLetter
+        $usedLetters += $systemLetter
+        
+        # Get OS partition drive letter (prefer W, but avoid conflicts)
+        $osLetter = Get-AvailableDriveLetter -PreferredLetters @('W') -ExcludeLetters $usedLetters
+        $assignments.OS = $osLetter
+        $usedLetters += $osLetter
+        
+        # Get recovery partition drive letter (prefer R)
+        $recoveryLetter = Get-AvailableDriveLetter -PreferredLetters @('R') -ExcludeLetters $usedLetters
+        $assignments.Recovery = $recoveryLetter
+        $usedLetters += $recoveryLetter
+        
+        # Get network share drive letter (prefer letters at end of alphabet to avoid conflicts)
+        $networkLetter = Get-AvailableDriveLetter -PreferredLetters @('Z', 'Y', 'X') -ExcludeLetters $usedLetters
+        $assignments.Network = $networkLetter
+        $usedLetters += $networkLetter
+        
+        WriteLog "Drive letter assignments:"
+        WriteLog "  System partition: $($assignments.System):"
+        WriteLog "  OS partition: $($assignments.OS):"
+        WriteLog "  Recovery partition: $($assignments.Recovery):"
+        WriteLog "  Network share: $($assignments.Network):"
+        
+        return $assignments
+    }
+    catch {
+        WriteLog "Error assigning drive letters: $($_.Exception.Message)"
+        throw "Failed to assign drive letters: $($_.Exception.Message)"
+    }
+}
+
 # Get drive letter assignments at script startup to avoid conflicts
 WriteLog "Initializing drive letter assignments to avoid conflicts..."
 try {
@@ -714,62 +770,6 @@ function Get-AvailableDriveLetter {
     }
     
     throw "No available drive letters found. Used: $($usedDriveLetters -join ', '), Excluded: $($ExcludeLetters -join ', ')"
-}
-
-function Get-DriveLetterAssignments {
-    <#
-    .SYNOPSIS
-    Gets drive letter assignments for all the partitions needed by the FFU creation process.
-    
-    .DESCRIPTION
-    This function assigns available drive letters for:
-    - System partition (prefers 'S')
-    - OS partition (prefers 'W') 
-    - Recovery partition (prefers 'R')
-    - Network share mapping (prefers 'X', 'Y', 'Z' to avoid conflicts)
-    
-    .OUTPUTS
-    Returns a hashtable with the assigned drive letters
-    #>
-    
-    WriteLog "Assigning available drive letters for FFU creation process..."
-    
-    $assignments = @{}
-    $usedLetters = @()
-    
-    try {
-        # Get system partition drive letter (prefer S)
-        $systemLetter = Get-AvailableDriveLetter -PreferredLetters @('S') -ExcludeLetters $usedLetters
-        $assignments.System = $systemLetter
-        $usedLetters += $systemLetter
-        
-        # Get OS partition drive letter (prefer W, but avoid conflicts)
-        $osLetter = Get-AvailableDriveLetter -PreferredLetters @('W') -ExcludeLetters $usedLetters
-        $assignments.OS = $osLetter
-        $usedLetters += $osLetter
-        
-        # Get recovery partition drive letter (prefer R)
-        $recoveryLetter = Get-AvailableDriveLetter -PreferredLetters @('R') -ExcludeLetters $usedLetters
-        $assignments.Recovery = $recoveryLetter
-        $usedLetters += $recoveryLetter
-        
-        # Get network share drive letter (prefer letters at end of alphabet to avoid conflicts)
-        $networkLetter = Get-AvailableDriveLetter -PreferredLetters @('Z', 'Y', 'X') -ExcludeLetters $usedLetters
-        $assignments.Network = $networkLetter
-        $usedLetters += $networkLetter
-        
-        WriteLog "Drive letter assignments:"
-        WriteLog "  System partition: $($assignments.System):"
-        WriteLog "  OS partition: $($assignments.OS):"
-        WriteLog "  Recovery partition: $($assignments.Recovery):"
-        WriteLog "  Network share: $($assignments.Network):"
-        
-        return $assignments
-    }
-    catch {
-        WriteLog "Error assigning drive letters: $($_.Exception.Message)"
-        throw "Failed to assign drive letters: $($_.Exception.Message)"
-    }
 }
 
 function Clear-NetworkDriveMapping {


### PR DESCRIPTION
Move `Get-DriveLetterAssignments` function definition to before its first call to resolve "command not recognized" error.

The build process failed because the `Get-DriveLetterAssignments` function was invoked on line 637, but its definition was located later in the script on line 719. PowerShell does not support function hoisting, meaning functions must be defined before they are called. This PR corrects the order of definition and invocation.

---
<a href="https://cursor.com/background-agent?bcId=bc-856a5b2e-94aa-43ef-8b00-6bb7f33cc02c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-856a5b2e-94aa-43ef-8b00-6bb7f33cc02c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

